### PR TITLE
increased bodyParser limits

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ const express = require('express')
 const app = express();
 const port = 9123;
 
-app.use(bodyParser.json());
-app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json({limit: '10mb', extended: true}));
+app.use(bodyParser.urlencoded({limit: '10mb', extended: true }));
 
 app.use('/', express.static('public'));
 


### PR DESCRIPTION
Received a "PayloadTooLargeError: request entity too large" error when trying to convert RPGLE source of just over 2.5k lines. The default limit for bodyParser.json is 100kb so around 1000 lines. This fix was taken from PR #16 (thanks @sagartyagi121) but thought it might be easier to merge as an individual change.